### PR TITLE
Fix authority/subject key typo for ECC

### DIFF
--- a/lib/x509/certificate/extension.ex
+++ b/lib/x509/certificate/extension.ex
@@ -164,7 +164,7 @@ defmodule X509.Certificate.Extension do
 
   def subject_key_identifier({ec_point(), _parameters} = public_key) do
     :crypto.hash(:sha, X509.PublicKey.to_der(public_key))
-    |> authority_key_identifier()
+    |> subject_key_identifier()
   end
 
   def subject_key_identifier(id) when is_binary(id) do


### PR DESCRIPTION
The typo had the effect of adding the authority key identifier where the
subject key identifier was supposed to be. This fixes it.