### PR TITLE
Bump default serial number length to 20 bytes

### DIFF
--- a/lib/x509/certificate.ex
+++ b/lib/x509/certificate.ex
@@ -37,8 +37,9 @@ defmodule X509.Certificate do
     a built-in template (default: `:server`)
   * `:hash` - the hashing algorithm to use when signing the certificate
     (default: from template)
-  * `:serial` - the certificate's serial number (default: from template, where
-    it will typically be set to `nil`, resulting in a random value)
+  * `:serial` - the certificate's serial number, `{:random, n}` to generate
+    an n-byte random value, or `nil`. (default: from template, where it will typically be
+    set to `nil`, resulting in an 8-byte random value)
   * `:validity` - an integer specifying the certificate's validity in days,
     or an `X509.Certificate.Validity` record defining the 'not before' and
     'not after' timestamps (default: from template)
@@ -316,7 +317,12 @@ defmodule X509.Certificate do
   defp new_otp_tbs_certificate(public_key, subject_rdn, issuer_rdn, algorithm, template) do
     otp_tbs_certificate(
       version: @version,
-      serialNumber: Map.get(template, :serial) || random_serial(8),
+      serialNumber:
+        case Map.get(template, :serial) do
+          nil -> random_serial(8)
+          {:random, n} -> random_serial(n)
+          serial -> serial
+        end,
       signature: algorithm,
       issuer:
         case issuer_rdn do

--- a/lib/x509/certificate/template.ex
+++ b/lib/x509/certificate/template.ex
@@ -64,11 +64,12 @@ defmodule X509.Certificate.Template do
   ## Options:
 
     * `:hash` - the hash algorithm to use when signing the certificate
-    * `:serial` - the serial number of the certificate; if set to `nil`, a
-      random serial number will be assigned
+    * `:serial` - the serial number of the certificate, `{:random, n}` to
+      generate an n-byte random serial number, or `nil` for the default
+      which is an 8-byte random serial number
     * `:validity` - override the validity period; can be specified as the
       number of days (integer) or a `X509.Certificate.Validity` value
-    * `:extensions` - a keyword list of extentions to be merged into the
+    * `:extensions` - a keyword list of extensions to be merged into the
       template's defaults; set an extension value to `false` to exclude that
       extension from the certificate
 


### PR DESCRIPTION
How do you feel about bumping the default serial number length to 20 bytes to match OpenSSL's default length? It's unclear whether the extra bytes will do us any good, but the different serial number length was noticed and questioned, so I figured that I'd submit this for your consideration.