### PR TITLE
Use subject from issuer certificate instead of its issuer

### DIFF
--- a/lib/x509/certificate.ex
+++ b/lib/x509/certificate.ex
@@ -70,11 +70,11 @@ defmodule X509.Certificate do
       case issuer do
         certificate(tbsCertificate: tbs) ->
           tbs
-          |> otp_tbs_certificate(:issuer)
+          |> otp_tbs_certificate(:subject)
           |> :pubkey_cert_records.transform(:decode)
 
         otp_certificate(tbsCertificate: tbs) ->
-          otp_tbs_certificate(tbs, :issuer)
+          otp_tbs_certificate(tbs, :subject)
       end
 
     public_key


### PR DESCRIPTION
I've been testing the creation and validity of a chain of `root.pem -> intermediate.pem -> user.pem` certificates and found that I was receiving errors when verifying the chain validity with `openssl verify -CAfile <(root.pem, intermediate.pem) user.pem`. After inspecting the certificates, I noticed that the issuer of `user.pem` was set to the subject from `root.pem`. After applying this change, the call to `openssl verify` passed.