### PR TITLE
Add helper function to get certificate serial number

### DIFF
--- a/lib/x509/certificate.ex
+++ b/lib/x509/certificate.ex
@@ -214,6 +214,16 @@ defmodule X509.Certificate do
   end
 
   @doc """
+  Return the serial number of the certificate.
+  """
+  @spec serial(t()) :: non_neg_integer()
+  def serial(cert) do
+    cert
+    |> otp_certificate(:tbsCertificate)
+    |> otp_tbs_certificate(:serialNumber)
+  end
+
+  @doc """
   Converts a certificate to DER (binary) format.
   """
   @spec to_der(t()) :: binary()
@@ -307,6 +317,13 @@ defmodule X509.Certificate do
       nil -> {:error, :not_found}
       {:Certificate, der, :not_encrypted} -> from_der(der, type)
     end
+  end
+
+  @doc false
+  # Returns a random serial number as an integer
+  def random_serial(size) do
+    <<i::unsigned-size(size)-unit(8)>> = :crypto.strong_rand_bytes(size)
+    i
   end
 
   #
@@ -409,12 +426,6 @@ defmodule X509.Certificate do
         false -> false
       end)
     end)
-  end
-
-  # Returns a random serial number as an integer
-  defp random_serial(size) do
-    <<i::unsigned-size(size)-unit(8)>> = :crypto.strong_rand_bytes(size)
-    i
   end
 
   # Returns a :SignatureAlgorithm record for the given public key type and hash

--- a/test/x509/certificate_test.exs
+++ b/test/x509/certificate_test.exs
@@ -92,4 +92,20 @@ defmodule X509.CertificateTest do
              |> :public_key.pkix_verify(X509.PublicKey.derive(context.ec_key))
     end
   end
+
+  test :serial_number, context do
+    serial = X509.Certificate.random_serial(8)
+
+    cert =
+      context.ec_key
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new(
+        "/C=US/ST=NT/L=Springfield/O=ACME Inc./CN=Example",
+        context.selfsigned_ecdsa,
+        context.selfsigned_ecdsa_key,
+        template: X509.Certificate.Template.new(:server, serial: serial)
+      )
+
+    assert X509.Certificate.serial(cert) == serial
+  end
 end


### PR DESCRIPTION
There are a handful of other helpers in the Certificate module. Not sure what your thought were on what in all you wanted to support, but, I've found this helpful. 