### PR TITLE
Remove opaque from certificate type specs

### DIFF
--- a/lib/x509/certificate.ex
+++ b/lib/x509/certificate.ex
@@ -17,7 +17,7 @@ defmodule X509.Certificate do
   @typedoc """
   `:OTPCertificate` record , as used in Erlang's `:public_key` module
   """
-  @opaque t :: X509.ASN1.record(:otp_certificate)
+  @type t :: X509.ASN1.record(:otp_certificate)
 
   @version :v3
 

--- a/lib/x509/certificate/extension.ex
+++ b/lib/x509/certificate/extension.ex
@@ -7,7 +7,7 @@ defmodule X509.Certificate.Extension do
   import X509.ASN1, except: [basic_constraints: 2, authority_key_identifier: 1]
 
   @typedoc "`:Extension` record, as used in Erlang's `:public_key` module"
-  @opaque t :: X509.ASN1.record(:extension)
+  @type t :: X509.ASN1.record(:extension)
 
   @type extension_id ::
           :basic_constraints

--- a/lib/x509/certificate/validity.ex
+++ b/lib/x509/certificate/validity.ex
@@ -12,7 +12,7 @@ defmodule X509.Certificate.Validity do
   @type time :: {:utcTime | :generalizedTime, charlist()}
 
   @typedoc "`:Validity` record, as used in Erlang's `:public_key` module"
-  @opaque t :: X509.ASN1.record(:validity)
+  @type t :: X509.ASN1.record(:validity)
 
   @default_backdate_seconds 5 * 60
   @seconds_per_day 24 * 60 * 60


### PR DESCRIPTION
This fixes Dialyzer errors in my use of the x509 library since I need to
access fields in the OTP types.

NOTE: This doesn't fix Dialyzer errors in `x509`. It's limited to only the things that cause Dialyzer errors in my use of the library.