### PR TITLE
Add _ character to list of printable string

### DIFF
--- a/lib/x509/rdn_sequence.ex
+++ b/lib/x509/rdn_sequence.ex
@@ -405,7 +405,7 @@ defmodule X509.RDNSequence do
                      ?A..?Z |> Enum.into([]),
                      ?a..?z |> Enum.into([]),
                      ?0..?9 |> Enum.into([]),
-                     ' \'()+,-./:=?'
+                     ' \'()+,-./:=?_'
                    ]
                    |> List.flatten()
 


### PR DESCRIPTION
I'm working with a certificate that has the following data in it:

```elixir
X509.RDNSequence.new("/serialNumber=eui48_6827194B53C2", :otp)
```

This raises an error:

```
** (EXIT from #PID<0.111.0>) shell process exited with reason: an exception was raised:
    ** (ArgumentError) unsupported character(s) in `PrintableString` attribute
        (x509 0.8.3) lib/x509/rdn_sequence.ex:431: X509.RDNSequence.printableString/2
        (x509 0.8.3) lib/x509/rdn_sequence.ex:357: X509.RDNSequence.new_attr/1
        (x509 0.8.3) lib/x509/rdn_sequence.ex:137: anonymous fn/1 in X509.RDNSequence.new/2
        (elixir 1.12.2) lib/enum.ex:1582: Enum."-map/2-lists^map/1-0-"/2
        (x509 0.8.3) lib/x509/rdn_sequence.ex:137: X509.RDNSequence.new/2
```

Simply adding the `_` character fixes it.
