### PR TITLE
 fixes surname handling for RDNSequence

### DIFF
--- a/lib/x509/rdn_sequence.ex
+++ b/lib/x509/rdn_sequence.ex
@@ -301,7 +301,7 @@ defmodule X509.RDNSequence do
   defp new_attr({"ST", value}), do: new_attr({:stateOrProvinceName, value})
   defp new_attr({"CN", value}), do: new_attr({:commonName, value})
   defp new_attr({"L", value}), do: new_attr({:localityName, value})
-  defp new_attr({"SN", value}), do: new_attr({:surName, value})
+  defp new_attr({"SN", value}), do: new_attr({:surname, value})
   defp new_attr({"GN", value}), do: new_attr({:givenName, value})
   defp new_attr({"DC", value}), do: new_attr({:domainComponent, value})
   defp new_attr({"E", value}), do: new_attr({:emailAddress, value})

--- a/test/x509/rdn_sequence_test.exs
+++ b/test/x509/rdn_sequence_test.exs
@@ -7,4 +7,8 @@ defmodule X509.RDNSequenceTest do
     # the spec; OTP's :public_key does the same
     assert {:rdnSequence, _} = X509.RDNSequence.new("/C=Germany/O=ACME GmbH")
   end
+
+  test "surname" do
+    assert {:rdnSequence, _} = X509.RDNSequence.new("/SN=Germany/O=ACME GmbH")
+  end
 end

--- a/test/x509/rdn_sequence_test.exs
+++ b/test/x509/rdn_sequence_test.exs
@@ -9,6 +9,6 @@ defmodule X509.RDNSequenceTest do
   end
 
   test "surname" do
-    assert {:rdnSequence, _} = X509.RDNSequence.new("/SN=Germany/O=ACME GmbH")
+    assert {:rdnSequence, _} = X509.RDNSequence.new("/SN=Erlang/GN=Agner Krarup")
   end
 end


### PR DESCRIPTION
surname used incosistent casing (:surName vs :surname) which led to
an error when providing a string with "SN=Doe" to RDNSequence.new for example.

Changes
- consistently use lowercase for the surname atom in RDNSequence.new_attr/1
- adds testcase to validate that a RDN Sequence with a provided "SN"
  returns without error in RDNSequenceTest