### PR TITLE
Add syntax_tools to extra_applications to fix compilation on Elixir 1.15

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,13 +15,13 @@ defmodule X509.MixProject do
       description: description(),
       package: package(),
       docs: docs(),
-      xref: [exclude: [IEx, :epp_dodger]]
+      xref: [exclude: [IEx]]
     ]
   end
 
   def application do
     [
-      extra_applications: [:crypto, :public_key, :logger, :ssl]
+      extra_applications: [:crypto, :public_key, :logger, :ssl, :syntax_tools]
     ]
   end
 


### PR DESCRIPTION
I saw [somewhere](https://github.com/voltone/x509/pull/38#issuecomment-706705912) a mention that this is a compile-only dependency? Unfortunately I don't know how it should be declared to be present during compilation but not when application starts. Maybe this is what `syntax_tools: :optional` in `:extra_applications` would do but I haven't tested building a release with this value.