### PR TITLE
Fix compilation on Elixir 1.15+

### DIFF
--- a/lib/x509/asn1/oid_import.ex
+++ b/lib/x509/asn1/oid_import.ex
@@ -1,6 +1,11 @@
 defmodule X509.ASN1.OIDImport do
   @moduledoc false
 
+  # TODO: Remove when we require Elixir 1.15
+  if function_exported?(Mix, :ensure_application!, 1) do
+    Mix.ensure_application!(:syntax_tools)
+  end
+
   def from_lib(file) do
     file
     |> from_lib_file()


### PR DESCRIPTION
`Mix.ensure_application!/1` was added in Elixir 1.15.

To quote docs at https://hexdocs.pm/mix/Mix.html#ensure_application!/1

> Ensures the given application from Erlang/OTP or Elixir and its dependencies are available in the path.
>
> This is mostly used for Mix internal needs. In your own tasks, you should list the Erlang application dependencies under the :extra_applications section of your mix.exs.

Closes #53