### PR TITLE
Replace deprecated `Logger.warn/1`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,21 +16,6 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: '1.5.3'
-              otp: '20.1.7.1'
-          - pair:
-              elixir: '1.6.6'
-              otp: '20.3.8.26'
-          - pair:
-              elixir: '1.6.6'
-              otp: '21.0.9'
-          - pair:
-              elixir: '1.8.2'
-              otp: '21.3.8.21'
-          - pair:
-              elixir: '1.10.4'
-              otp: '23.0.4'
-          - pair:
               elixir: '1.11.3'
               otp: '23.2.7'
           - pair:

--- a/lib/x509/test/crl_server.ex
+++ b/lib/x509/test/crl_server.ex
@@ -107,7 +107,7 @@ defmodule X509.Test.CRLServer do
       {:ok, :http_eoh} ->
         case Map.get(crl_map, path) do
           nil ->
-            Logger.warn("No CRL defined for #{path}")
+            Logger.warning("No CRL defined for #{path}")
             respond(socket, 404)
             :gen_tcp.close(socket)
 

--- a/lib/x509/test/suite.ex
+++ b/lib/x509/test/suite.ex
@@ -582,7 +582,7 @@ defmodule X509.Test.Suite do
         %__MODULE__{valid: valid, chain: chain, server_key: server_key},
         scenario
       ) do
-    Logger.warn("Unknown scenario: #{scenario}")
+    Logger.warning("Unknown scenario: #{scenario}")
 
     [
       cert: X509.Certificate.to_der(valid),

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule X509.MixProject do
     [
       app: :x509,
       version: @version,
-      elixir: "~> 1.5",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       name: "X509",

--- a/test/x509/test/server_test.exs
+++ b/test/x509/test/server_test.exs
@@ -839,7 +839,7 @@ defmodule X509.Test.ServerTest do
       end
     end
   else
-    Logger.warn("ECDSA certificates can't be tested on the current OTP version")
+    Logger.warning("ECDSA certificates can't be tested on the current OTP version")
   end
 
   #


### PR DESCRIPTION
with `Logger.warning/1`, available [since Elixir 1.11](https://hexdocs.pm/logger/Logger.html#warning/2), currently the oldest [supported Elixir version](https://hexdocs.pm/elixir/1.15.2/compatibility-and-deprecations.html).