### PR TITLE
Add :syntax_tools to extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule X509.MixProject do
   end
 
   defp extra_applications(_env) do
-    [:crypto, :public_key, :logger, :ssl]
+    [:crypto, :public_key, :logger, :ssl, :syntax_tools]
   end
 
   defp deps do


### PR DESCRIPTION
Due to [code path pruning introduced in Elixir 1.15](https://hexdocs.pm/elixir/1.15/changelog.html#potential-incompatibilities), this can fail compiling since `:syntax_tools` is not listed in `extra_applications`, but `:epp_dodger` from that app is used. It may cause a compilation error like the following:
```
== Compilation error in file lib/x509/asn1.ex ==
** (UndefinedFunctionError) function :epp_dodger.parse_file/1 is undefined (module :epp_dodger is not available)
    :epp_dodger.parse_file(~c"/usr/lib/erlang/lib/public_key-1.14.1/include/OTP-PUB-KEY.hrl")
    lib/x509/asn1/oid_import.ex:19: X509.ASN1.OIDImport.get_oids/1
    lib/x509/asn1.ex:84: (module)
could not compile dependency :x509, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile x509 --force", update it with "mix deps.update x509" or clean it with "mix deps.clean x509"
``