### PR TITLE
Don't warn on Logger.warn

### DIFF
--- a/lib/x509/logger.ex
+++ b/lib/x509/logger.ex
@@ -1,0 +1,16 @@
+defmodule X509.Logger do
+  @moduledoc false
+  alias X509.Util
+
+  require Logger
+
+  if Util.app_version(:elixir) >= [1, 11, 0] do
+    def warn(message, metadata \\ []) do
+      Logger.warning(message, metadata)
+    end
+  else
+    def warn(message, metadata \\ []) do
+      Logger.warn(message, metadata)
+    end
+  end
+end

--- a/lib/x509/logger.ex
+++ b/lib/x509/logger.ex
@@ -4,7 +4,7 @@ defmodule X509.Logger do
 
   require Logger
 
-  if Util.app_version(:elixir) >= [1, 11, 0] do
+  if Util.app_version(:logger) >= [1, 11, 0] do
     def warn(message, metadata \\ []) do
       Logger.warning(message, metadata)
     end

--- a/lib/x509/test/crl_server.ex
+++ b/lib/x509/test/crl_server.ex
@@ -106,7 +106,7 @@ defmodule X509.Test.CRLServer do
       {:ok, :http_eoh} ->
         case Map.get(crl_map, path) do
           nil ->
-            X509.Util.warn("No CRL defined for #{path}")
+            X509.Logger.warn("No CRL defined for #{path}")
             respond(socket, 404)
             :gen_tcp.close(socket)
 

--- a/lib/x509/test/suite.ex
+++ b/lib/x509/test/suite.ex
@@ -581,7 +581,7 @@ defmodule X509.Test.Suite do
         %__MODULE__{valid: valid, chain: chain, server_key: server_key},
         scenario
       ) do
-    X509.Util.warn("Unknown scenario: #{scenario}")
+    X509.Logger.warn("Unknown scenario: #{scenario}")
 
     [
       cert: X509.Certificate.to_der(valid),

--- a/lib/x509/util.ex
+++ b/lib/x509/util.ex
@@ -1,8 +1,6 @@
 defmodule X509.Util do
   @moduledoc false
 
-  require Logger
-
   def app_version(application) do
     application
     |> Application.spec()
@@ -10,17 +8,5 @@ defmodule X509.Util do
     |> to_string()
     |> String.split(".")
     |> Enum.map(&String.to_integer/1)
-  end
-
-  # Create a utility function that handles checking for the 
-  # existence of Logger.warning/2 if not fallback to Logger.warn/2
-  if macro_exported?(Logger, :warning, 2) do
-    def warn(message, metadata \\ []) do
-      Logger.warning(message, metadata)
-    end
-  else
-    def warn(message, metadata \\ []) do
-      Logger.warn(message, metadata)
-    end
   end
 end

--- a/test/x509/test/server_test.exs
+++ b/test/x509/test/server_test.exs
@@ -840,7 +840,7 @@ defmodule X509.Test.ServerTest do
       end
     end
   else
-    X509.Util.warn("ECDSA certificates can't be tested on the current OTP version")
+    X509.Logger.warn("ECDSA certificates can't be tested on the current OTP version")
   end
 
   #


### PR DESCRIPTION
Problem.

The old approach checked if `Logger.warn` was available but it could be already deprecated creating warnings.
This approach checks if we are at version 1.11.0 or above to use newer `warning` where possible.