### PR TITLE
Remove deprecated charlist syntax

### DIFF
--- a/lib/x509/certificate/extension.ex
+++ b/lib/x509/certificate/extension.ex
@@ -250,11 +250,11 @@ defmodule X509.Certificate.Extension do
 
       iex> X509.Certificate.Extension.subject_alt_name(["www.example.com", "example.com"])
       {:Extension, {2, 5, 29, 17}, false,
-       [dNSName: 'www.example.com', dNSName: 'example.com']}
+       [dNSName: ~c'www.example.com', dNSName: ~c'example.com']}
 
-      iex> X509.Certificate.Extension.subject_alt_name(emailAddress: 'user@example.com')
+      iex> X509.Certificate.Extension.subject_alt_name(emailAddress: ~c'user@example.com')
       {:Extension, {2, 5, 29, 17}, false,
-       [emailAddress: 'user@example.com']}
+       [emailAddress: ~c'user@example.com']}
   """
   @spec subject_alt_name([san_value()]) :: t()
   def subject_alt_name(value) do
@@ -289,7 +289,7 @@ defmodule X509.Certificate.Extension do
       {:Extension, {2, 5, 29, 31}, false,
        [
          {:DistributionPoint,
-          {:fullName, [uniformResourceIdentifier: 'http://crl.example.org/root.crl']},
+          {:fullName, [uniformResourceIdentifier: ~c'http://crl.example.org/root.crl']},
           :asn1_NOVALUE, :asn1_NOVALUE}
        ]}
   """

--- a/lib/x509/certificate/validity.ex
+++ b/lib/x509/certificate/validity.ex
@@ -26,13 +26,13 @@ defmodule X509.Certificate.Validity do
       iex> {:ok, not_before, 0} = DateTime.from_iso8601("2018-01-01T00:00:00Z")
       iex> {:ok, not_after, 0} = DateTime.from_iso8601("2018-12-31T23:59:59Z")
       iex> X509.Certificate.Validity.new(not_before, not_after)
-      {:Validity, {:utcTime, '180101000000Z'}, {:utcTime, '181231235959Z'}}
+      {:Validity, {:utcTime, ~c'180101000000Z'}, {:utcTime, ~c'181231235959Z'}}
 
       iex> {:ok, not_before, 0} = DateTime.from_iso8601("2051-01-01T00:00:00Z")
       iex> {:ok, not_after, 0} = DateTime.from_iso8601("2051-12-31T23:59:59Z")
       iex> X509.Certificate.Validity.new(not_before, not_after)
-      {:Validity, {:generalTime, '20510101000000Z'},
-        {:generalTime, '20511231235959Z'}}
+      {:Validity, {:generalTime, ~c'20510101000000Z'},
+        {:generalTime, ~c'20511231235959Z'}}
   """
   @spec new(DateTime.t(), DateTime.t()) :: t()
   def new(%DateTime{} = not_before, %DateTime{} = not_after) do

--- a/lib/x509/date_time.ex
+++ b/lib/x509/date_time.ex
@@ -27,7 +27,7 @@ defmodule X509.DateTime do
   def utc_time(%DateTime{} = datetime) do
     iso = DateTime.to_iso8601(datetime, :basic)
     [_, date, time] = Regex.run(~r/^\d\d(\d{6})T(\d{6})(?:\.\d+)?Z$/, iso)
-    '#{date}#{time}Z'
+    ~c'#{date}#{time}Z'
   end
 
   # Builds ASN.1 GeneralTime as charlist
@@ -40,7 +40,7 @@ defmodule X509.DateTime do
   def general_time(%DateTime{} = datetime) do
     iso = DateTime.to_iso8601(datetime, :basic)
     [_, date, time] = Regex.run(~r/^(\d{8})T(\d{6})(?:\.\d+)?Z$/, iso)
-    '#{date}#{time}Z'
+    ~c'#{date}#{time}Z'
   end
 
   def to_datetime({:utcTime, time}) do

--- a/lib/x509/private_key.ex
+++ b/lib/x509/private_key.ex
@@ -236,7 +236,7 @@ defmodule X509.PrivateKey do
   def from_pem(pem, opts \\ []) do
     password =
       opts
-      |> Keyword.get(:password, '')
+      |> Keyword.get(:password, ~c'')
       |> to_charlist()
 
     pem
@@ -307,6 +307,6 @@ defmodule X509.PrivateKey do
   end
 
   defp cipher_info() do
-    {'DES-EDE3-CBC', :crypto.strong_rand_bytes(8)}
+    {~c'DES-EDE3-CBC', :crypto.strong_rand_bytes(8)}
   end
 end

--- a/lib/x509/rdn_sequence.ex
+++ b/lib/x509/rdn_sequence.ex
@@ -405,7 +405,7 @@ defmodule X509.RDNSequence do
                      ?A..?Z |> Enum.into([]),
                      ?a..?z |> Enum.into([]),
                      ?0..?9 |> Enum.into([]),
-                     ' \'()+,-./:=?'
+                     ~c' \'()+,-./:=?'
                    ]
                    |> List.flatten()
 

--- a/test/x509/certificate/extension_test.exs
+++ b/test/x509/certificate/extension_test.exs
@@ -63,7 +63,7 @@ defmodule X509.Certificate.ExtensionTest do
       assert certs.server
              |> X509.Certificate.extension(:subject_alt_name)
              |> extension(:extnValue) ==
-               [dNSName: '*.tools.ietf.org', dNSName: 'tools.ietf.org']
+               [dNSName: ~c'*.tools.ietf.org', dNSName: ~c'tools.ietf.org']
     end
 
     test "crl_distribution_points", %{certs: certs} do
@@ -73,7 +73,7 @@ defmodule X509.Certificate.ExtensionTest do
                {:DistributionPoint,
                 {:fullName,
                  [
-                   uniformResourceIdentifier: 'http://crl.starfieldtech.com/sfig2s1-128.crl'
+                   uniformResourceIdentifier: ~c'http://crl.starfieldtech.com/sfig2s1-128.crl'
                  ]}, :asn1_NOVALUE, :asn1_NOVALUE}
              ]
     end
@@ -83,10 +83,10 @@ defmodule X509.Certificate.ExtensionTest do
              |> X509.Certificate.extension(:authority_info_access)
              |> extension(:extnValue) == [
                {:AccessDescription, {1, 3, 6, 1, 5, 5, 7, 48, 1},
-                {:uniformResourceIdentifier, 'http://ocsp.starfieldtech.com/'}},
+                {:uniformResourceIdentifier, ~c'http://ocsp.starfieldtech.com/'}},
                {:AccessDescription, {1, 3, 6, 1, 5, 5, 7, 48, 2},
                 {:uniformResourceIdentifier,
-                 'http://certificates.starfieldtech.com/repository/sfig2.crt'}}
+                 ~c'http://certificates.starfieldtech.com/repository/sfig2.crt'}}
              ]
     end
 

--- a/test/x509/certificate/validity_test.exs
+++ b/test/x509/certificate/validity_test.exs
@@ -8,7 +8,7 @@ defmodule X509.Certificate.ValidityTest do
     validity = X509.Certificate.Validity.new(not_before, not_after)
     assert <<der::binary>> = :public_key.der_encode(:Validity, validity)
 
-    assert {:Validity, {:utcTime, '220101000000Z'}, {:generalTime, '20511231235959Z'}} =
+    assert {:Validity, {:utcTime, ~c'220101000000Z'}, {:generalTime, ~c'20511231235959Z'}} =
              :public_key.der_decode(:Validity, der)
   end
 end

--- a/test/x509/certificate_test.exs
+++ b/test/x509/certificate_test.exs
@@ -116,7 +116,7 @@ defmodule X509.CertificateTest do
                |> X509.Certificate.extension(:key_usage)
                |> extension(:extnValue)
 
-      assert [rfc822Name: 'end.entity@example.com'] =
+      assert [rfc822Name: ~c'end.entity@example.com'] =
                cert2
                |> X509.Certificate.extension(:subject_alt_name)
                |> extension(:extnValue)

--- a/test/x509/test/server_test.exs
+++ b/test/x509/test/server_test.exs
@@ -14,7 +14,7 @@ defmodule X509.Test.ServerTest do
   # scenario, e.g.:
   #
   #   ```
-  #   request('https://valid.#{context.suite.domain}:#{context.port}/',
+  #   request(~c'https://valid.#{context.suite.domain}:#{context.port}/',
   #     cacertfile: context.cacertfile,
   #     log_level: :debug
   #   )
@@ -97,14 +97,14 @@ defmodule X509.Test.ServerTest do
 
     test "valid", context do
       assert {:ok, _} =
-               request('https://valid.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
     end
 
     test "valid-missing-chain", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -116,7 +116,7 @@ defmodule X509.Test.ServerTest do
       # intermediate CAs from the provided trust store
       if version(:ssl) >= [9, 0, 2] do
         assert {:ok, _} =
-                 request('https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile_with_chain
                  )
       end
@@ -124,7 +124,7 @@ defmodule X509.Test.ServerTest do
 
     test "valid-expired-chain", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://valid-expired-chain.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-expired-chain.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -133,7 +133,7 @@ defmodule X509.Test.ServerTest do
 
     test "valid-revoked-chain", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://valid-revoked-chain.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-revoked-chain.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -142,7 +142,7 @@ defmodule X509.Test.ServerTest do
 
     test "valid-wrong-key", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://valid-wrong-key.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-wrong-key.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -151,7 +151,7 @@ defmodule X509.Test.ServerTest do
 
     test "valid-wrong-host", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://valid-wrong-host.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-wrong-host.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -167,7 +167,7 @@ defmodule X509.Test.ServerTest do
     @tag :known_to_fail
     test "valid-cross-signed, cross-signed CA", context do
       assert {:ok, _} =
-               request('https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
     end
@@ -176,7 +176,7 @@ defmodule X509.Test.ServerTest do
       # TODO: this only works with 'best effort' CRL checks; this may be an
       # issue with the test suite
       assert {:ok, _} =
-               request('https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.alternate_cacertfile,
                  crl_check: :best_effort
                )
@@ -188,7 +188,7 @@ defmodule X509.Test.ServerTest do
       # versions this test would fail
       if version(:public_key) >= [1, 6] do
         assert {:ok, _} =
-                 request('https://valid.wildcard.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid.wildcard.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
       end
@@ -196,7 +196,7 @@ defmodule X509.Test.ServerTest do
 
     test "wildcard, bare domain", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://wildcard.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://wildcard.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -206,7 +206,7 @@ defmodule X509.Test.ServerTest do
     test "invalid.subdomain.wildcard", context do
       assert {:error, {:tls_alert, reason}} =
                request(
-                 'https://invalid.subdomain.wildcard.#{context.suite.domain}:#{context.port}/',
+                 ~c'https://invalid.subdomain.wildcard.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -215,7 +215,7 @@ defmodule X509.Test.ServerTest do
 
     test "expired", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://expired.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://expired.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -224,7 +224,7 @@ defmodule X509.Test.ServerTest do
 
     test "revoked", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://revoked.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://revoked.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -233,7 +233,7 @@ defmodule X509.Test.ServerTest do
 
     test "selfsigned", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://selfsigned.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://selfsigned.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -242,7 +242,7 @@ defmodule X509.Test.ServerTest do
 
     test "client-cert", context do
       assert {:error, error} =
-               request('https://client-cert.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://client-cert.#{context.suite.domain}:#{context.port}/',
                  cacertfile: context.cacertfile
                )
 
@@ -264,7 +264,7 @@ defmodule X509.Test.ServerTest do
       end
 
       assert {:ok, _} =
-               request('https://client-cert.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://client-cert.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.chain ++ context.suite.cacerts,
                  cert: X509.Certificate.to_der(context.suite.client),
                  key: {:RSAPrivateKey, X509.PrivateKey.to_der(context.suite.client_key)}
@@ -277,14 +277,14 @@ defmodule X509.Test.ServerTest do
 
     test "valid", context do
       assert {:ok, _} =
-               request('https://valid.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
     end
 
     test "valid-missing-chain", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -300,7 +300,7 @@ defmodule X509.Test.ServerTest do
         # issuer of the peer certificate in this case is taken from `cacerts`,
         # no CRL checks can be performed
         assert {:ok, _} =
-                 request('https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts ++ context.suite.chain,
                    crl_check: false
                  )
@@ -309,7 +309,7 @@ defmodule X509.Test.ServerTest do
 
     test "valid-expired-chain", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://valid-expired-chain.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-expired-chain.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -321,7 +321,7 @@ defmodule X509.Test.ServerTest do
     @tag :known_to_fail
     test "valid-revoked-chain", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://valid-revoked-chain.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-revoked-chain.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -330,7 +330,7 @@ defmodule X509.Test.ServerTest do
 
     test "valid-wrong-key", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://valid-wrong-key.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-wrong-key.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -339,7 +339,7 @@ defmodule X509.Test.ServerTest do
 
     test "valid-wrong-host", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://valid-wrong-host.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-wrong-host.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -355,7 +355,7 @@ defmodule X509.Test.ServerTest do
     @tag :known_to_fail
     test "valid-cross-signed, cross-signed CA", context do
       assert {:ok, _} =
-               request('https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
     end
@@ -364,7 +364,7 @@ defmodule X509.Test.ServerTest do
       # TODO: this does not work with CRL checks at all, not even peer-only;
       # this may be an issue with the test suite
       assert {:ok, _} =
-               request('https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.alternate_cacerts,
                  crl_check: false
                )
@@ -376,7 +376,7 @@ defmodule X509.Test.ServerTest do
       # versions this test would fail
       if version(:public_key) >= [1, 6] do
         assert {:ok, _} =
-                 request('https://valid.wildcard.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid.wildcard.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
       end
@@ -384,7 +384,7 @@ defmodule X509.Test.ServerTest do
 
     test "wildcard, bare domain", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://wildcard.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://wildcard.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -394,7 +394,7 @@ defmodule X509.Test.ServerTest do
     test "invalid.subdomain.wildcard", context do
       assert {:error, {:tls_alert, reason}} =
                request(
-                 'https://invalid.subdomain.wildcard.#{context.suite.domain}:#{context.port}/',
+                 ~c'https://invalid.subdomain.wildcard.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -403,7 +403,7 @@ defmodule X509.Test.ServerTest do
 
     test "expired", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://expired.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://expired.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -416,7 +416,7 @@ defmodule X509.Test.ServerTest do
     @tag :known_to_fail
     test "revoked", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://revoked.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://revoked.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -425,7 +425,7 @@ defmodule X509.Test.ServerTest do
 
     test "selfsigned", context do
       assert {:error, {:tls_alert, reason}} =
-               request('https://selfsigned.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://selfsigned.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -434,7 +434,7 @@ defmodule X509.Test.ServerTest do
 
     test "client-cert", context do
       assert {:error, error} =
-               request('https://client-cert.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://client-cert.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.cacerts
                )
 
@@ -456,7 +456,7 @@ defmodule X509.Test.ServerTest do
       end
 
       assert {:ok, _} =
-               request('https://client-cert.#{context.suite.domain}:#{context.port}/',
+               request(~c'https://client-cert.#{context.suite.domain}:#{context.port}/',
                  cacerts: context.suite.chain ++ context.suite.cacerts,
                  cert: X509.Certificate.to_der(context.suite.client),
                  key: {:RSAPrivateKey, X509.PrivateKey.to_der(context.suite.client_key)}
@@ -471,14 +471,14 @@ defmodule X509.Test.ServerTest do
 
       test "valid", context do
         assert {:ok, _} =
-                 request('https://valid.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
       end
 
       test "valid-missing-chain", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -490,7 +490,7 @@ defmodule X509.Test.ServerTest do
         # intermediate CAs from the provided trust store
         if version(:ssl) >= [9, 0, 2] do
           assert {:ok, _} =
-                   request('https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
+                   request(~c'https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
                      cacertfile: context.cacertfile_with_chain
                    )
         end
@@ -498,7 +498,7 @@ defmodule X509.Test.ServerTest do
 
       test "valid-expired-chain", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://valid-expired-chain.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-expired-chain.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -507,7 +507,7 @@ defmodule X509.Test.ServerTest do
 
       test "valid-revoked-chain", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://valid-revoked-chain.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-revoked-chain.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -516,7 +516,7 @@ defmodule X509.Test.ServerTest do
 
       test "valid-wrong-key", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://valid-wrong-key.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-wrong-key.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -525,7 +525,7 @@ defmodule X509.Test.ServerTest do
 
       test "valid-wrong-host", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://valid-wrong-host.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-wrong-host.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -541,7 +541,7 @@ defmodule X509.Test.ServerTest do
       @tag :known_to_fail
       test "valid-cross-signed, cross-signed CA", context do
         assert {:ok, _} =
-                 request('https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
       end
@@ -550,7 +550,7 @@ defmodule X509.Test.ServerTest do
         # TODO: this only works with 'best effort' CRL checks; this may be an
         # issue with the test suite
         assert {:ok, _} =
-                 request('https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.alternate_cacertfile,
                    crl_check: :best_effort
                  )
@@ -562,7 +562,7 @@ defmodule X509.Test.ServerTest do
         # versions this test would fail
         if version(:public_key) >= [1, 6] do
           assert {:ok, _} =
-                   request('https://valid.wildcard.#{context.suite.domain}:#{context.port}/',
+                   request(~c'https://valid.wildcard.#{context.suite.domain}:#{context.port}/',
                      cacertfile: context.cacertfile
                    )
         end
@@ -570,7 +570,7 @@ defmodule X509.Test.ServerTest do
 
       test "wildcard, bare domain", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://wildcard.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://wildcard.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -580,7 +580,7 @@ defmodule X509.Test.ServerTest do
       test "invalid.subdomain.wildcard", context do
         assert {:error, {:tls_alert, reason}} =
                  request(
-                   'https://invalid.subdomain.wildcard.#{context.suite.domain}:#{context.port}/',
+                   ~c'https://invalid.subdomain.wildcard.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -589,7 +589,7 @@ defmodule X509.Test.ServerTest do
 
       test "expired", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://expired.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://expired.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -598,7 +598,7 @@ defmodule X509.Test.ServerTest do
 
       test "revoked", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://revoked.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://revoked.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -607,7 +607,7 @@ defmodule X509.Test.ServerTest do
 
       test "selfsigned", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://selfsigned.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://selfsigned.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -616,7 +616,7 @@ defmodule X509.Test.ServerTest do
 
       test "client-cert", context do
         assert {:error, error} =
-                 request('https://client-cert.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://client-cert.#{context.suite.domain}:#{context.port}/',
                    cacertfile: context.cacertfile
                  )
 
@@ -638,7 +638,7 @@ defmodule X509.Test.ServerTest do
         end
 
         assert {:ok, _} =
-                 request('https://client-cert.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://client-cert.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.chain ++ context.suite.cacerts,
                    cert: X509.Certificate.to_der(context.suite.client),
                    key: {:ECPrivateKey, X509.PrivateKey.to_der(context.suite.client_key)}
@@ -651,14 +651,14 @@ defmodule X509.Test.ServerTest do
 
       test "valid", context do
         assert {:ok, _} =
-                 request('https://valid.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
       end
 
       test "valid-missing-chain", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -674,7 +674,7 @@ defmodule X509.Test.ServerTest do
           # issuer of the peer certificate in this case is taken from `cacerts`,
           # no CRL checks can be performed
           assert {:ok, _} =
-                   request('https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
+                   request(~c'https://valid-missing-chain.#{context.suite.domain}:#{context.port}/',
                      cacerts: context.suite.cacerts ++ context.suite.chain,
                      crl_check: false
                    )
@@ -683,7 +683,7 @@ defmodule X509.Test.ServerTest do
 
       test "valid-expired-chain", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://valid-expired-chain.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-expired-chain.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -695,7 +695,7 @@ defmodule X509.Test.ServerTest do
       @tag :known_to_fail
       test "valid-revoked-chain", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://valid-revoked-chain.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-revoked-chain.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -704,7 +704,7 @@ defmodule X509.Test.ServerTest do
 
       test "valid-wrong-key", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://valid-wrong-key.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-wrong-key.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -713,7 +713,7 @@ defmodule X509.Test.ServerTest do
 
       test "valid-wrong-host", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://valid-wrong-host.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-wrong-host.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -729,7 +729,7 @@ defmodule X509.Test.ServerTest do
       @tag :known_to_fail
       test "valid-cross-signed, cross-signed CA", context do
         assert {:ok, _} =
-                 request('https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
       end
@@ -738,7 +738,7 @@ defmodule X509.Test.ServerTest do
         # TODO: this does not work with CRL checks at all, not even peer-only;
         # this may be an issue with the test suite
         assert {:ok, _} =
-                 request('https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://valid-cross-signed.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.alternate_cacerts,
                    crl_check: false
                  )
@@ -750,7 +750,7 @@ defmodule X509.Test.ServerTest do
         # versions this test would fail
         if version(:public_key) >= [1, 6] do
           assert {:ok, _} =
-                   request('https://valid.wildcard.#{context.suite.domain}:#{context.port}/',
+                   request(~c'https://valid.wildcard.#{context.suite.domain}:#{context.port}/',
                      cacerts: context.suite.cacerts
                    )
         end
@@ -758,7 +758,7 @@ defmodule X509.Test.ServerTest do
 
       test "wildcard, bare domain", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://wildcard.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://wildcard.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -768,7 +768,7 @@ defmodule X509.Test.ServerTest do
       test "invalid.subdomain.wildcard", context do
         assert {:error, {:tls_alert, reason}} =
                  request(
-                   'https://invalid.subdomain.wildcard.#{context.suite.domain}:#{context.port}/',
+                   ~c'https://invalid.subdomain.wildcard.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -777,7 +777,7 @@ defmodule X509.Test.ServerTest do
 
       test "expired", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://expired.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://expired.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -790,7 +790,7 @@ defmodule X509.Test.ServerTest do
       @tag :known_to_fail
       test "revoked", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://revoked.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://revoked.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -799,7 +799,7 @@ defmodule X509.Test.ServerTest do
 
       test "selfsigned", context do
         assert {:error, {:tls_alert, reason}} =
-                 request('https://selfsigned.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://selfsigned.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -808,7 +808,7 @@ defmodule X509.Test.ServerTest do
 
       test "client-cert", context do
         assert {:error, error} =
-                 request('https://client-cert.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://client-cert.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.cacerts
                  )
 
@@ -830,7 +830,7 @@ defmodule X509.Test.ServerTest do
         end
 
         assert {:ok, _} =
-                 request('https://client-cert.#{context.suite.domain}:#{context.port}/',
+                 request(~c'https://client-cert.#{context.suite.domain}:#{context.port}/',
                    cacerts: context.suite.chain ++ context.suite.cacerts,
                    cert: X509.Certificate.to_der(context.suite.client),
                    key: {:ECPrivateKey, X509.PrivateKey.to_der(context.suite.client_key)}
@@ -891,11 +891,17 @@ defmodule X509.Test.ServerTest do
     [suite: suite, port: port]
   end
 
+  if function_exported?(System, :pid, 0) do
+    defp system_pid, do: System.pid()
+  else
+    defp system_pid, do: System.get_pid()
+  end
+
   # Create PEM files for various CA stores used in test cases
   defp create_pem_files(context) do
     tmp_dir =
       System.tmp_dir!()
-      |> Path.join("x509_server_test#{System.get_pid()}")
+      |> Path.join("x509_server_test#{system_pid()}")
 
     File.mkdir(tmp_dir)
 


### PR DESCRIPTION
As per the title. @voltone I went with `~c''` but I can go with `~c""` too if you prefer that.