### PR TITLE
Fix failure to compile on weird Logger versions

### DIFF
--- a/lib/x509/util.ex
+++ b/lib/x509/util.ex
@@ -7,6 +7,9 @@ defmodule X509.Util do
     |> Keyword.get(:vsn)
     |> to_string()
     |> String.split(".")
-    |> Enum.map(&String.to_integer/1)
+    |> Enum.map(fn str ->
+      {num, _} = Integer.parse(str)
+      num
+    end)
   end
 end


### PR DESCRIPTION
For projects using a non-final release of Logger, such as seen with NextLS using an x.x.0-dev version. x509 would fail to build due to a parsing problem.

This made the editor tooling fail which was exciting.