### PR TITLE
Backfill changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.8.9 (2024-06-24)
+
+### Enhancements
+
+* Support OTP 27
+* Clean up deprecation warnings
+
 ## v0.8.8 (2023-08-30)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.8.10 (2024-10-16)
+
+### Fixes
+
+* Fix version check for Elixir by [@wojtekmach](https://github.com/wojtekmach)
+* Ensure application is started before running task by [@josevalim](https://github.com/josevalim)
+* Remove unnecessary file accidentally included in Hex package of v0.8.9 (as reported in [#79](https://github.com/voltone/x509/issues/79))
+
 ## v0.8.9 (2024-06-24)
 
 ### Enhancements


### PR DESCRIPTION
While upgrading our dependencies, I noticed that there is a gab in changelog for last two versions.

Thank you for your work on this project!