### PR TITLE
OTP 28.0.2 support

### DIFF
--- a/lib/x509/asn1.ex
+++ b/lib/x509/asn1.ex
@@ -43,7 +43,7 @@ defmodule X509.ASN1 do
              certification_request_subject_pk_info_algorithm:
                :CertificationRequestInfo_subjectPKInfo_algorithm,
              certification_request_signature_algorithm: :CertificationRequest_signatureAlgorithm,
-             certification_request_attribute: :"AttributePKCS-10",
+             certification_request_attribute: :Attribute,
 
              # Certificates
              certificate: :Certificate,


### PR DESCRIPTION
Compilation fails on OTP 28.0.2:
```
== Compilation error in file lib/x509/asn1.ex ==
** (ArgumentError) no record AttributePKCS-10 found at /Users/mkuratczyk/.kerl/28.0.2/lib/public_key-1.18.2/include/PKCS-FRAME.hrl. Or the record does not exist or its entry is malformed or depends on other include files
    (elixir 1.18.4) lib/record/extractor.ex:56: Record.Extractor.extract_record/2
    lib/x509/asn1.ex:84: anonymous fn/1 in :elixir_compiler_9.__MODULE__/1
    (elixir 1.18.4) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
    lib/x509/asn1.ex:68: (module)
```

With this change, it compiles and passes all tests on both 28.0.2 as well as 28.0.1.

I'm somewhat lost with all the public key related changes, so please make sure this is the right change. Thanks