### PR TITLE
Fix Elixir 1.20 xref warnings

### DIFF
--- a/lib/x509/certificate.ex
+++ b/lib/x509/certificate.ex
@@ -368,7 +368,7 @@ defmodule X509.Certificate do
   @doc false
   # Returns a random serial number as an integer
   def random_serial(size) do
-    <<i::unsigned-size(size)-unit(8)>> = :crypto.strong_rand_bytes(size)
+    <<i::unsigned-size(^size)-unit(8)>> = :crypto.strong_rand_bytes(size)
     i
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule X509.MixProject do
       description: description(),
       package: package(),
       docs: docs(),
-      xref: [exclude: [IEx, :epp_dodger]]
+      elixirc_options: [no_warn_undefined: [IEx, :epp_dodger]]
     ]
   end
 


### PR DESCRIPTION
Resolve compilation warnings in Elixir 1.20 by updating deprecated xref usage in mix.exs